### PR TITLE
Force User Agent to most common one

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,7 @@ function createWin() {
         show: false
     });
     win.setMenuBarVisibility(false);
-    win.loadURL("https://deezer.com");
+    win.loadURL("https://deezer.com",{userAgent: 'Chrome'});
     win.webContents.on('did-fail-load', (e, errCode, errMessage) => {
         //On some systems, this error occurs without explanation
         if (errCode == -3)

--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,7 @@ function createWin() {
         show: false
     });
     win.setMenuBarVisibility(false);
-    win.loadURL("https://deezer.com",{userAgent: 'Chrome'});
+    win.loadURL("https://deezer.com",{userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36'});
     win.webContents.on('did-fail-load', (e, errCode, errMessage) => {
         //On some systems, this error occurs without explanation
         if (errCode == -3)

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deezer-unofficial-player",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A electron built deezer player",
   "main": "app.js",
   "author": "Felipe Minetto<fminetto44@gmail.com>",


### PR DESCRIPTION
I forced the user agent to the most common one, found on [Most Common User Agents](https://techblog.willshouse.com/2012/01/03/most-common-user-agents/)

=> Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36