### PR TITLE
Adding support for MPRIS track informations

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,12 +2,22 @@ const path = require('path'),
     Datastore = require('nedb'),
     { Window } = require('./utils/window'),
     consvol = 0.10,
+    Player = require('mpris-service'),
     electron = require('electron'),
-    { app, Menu, Tray, globalShortcut, session } = electron,
+    { app, Menu, Tray, globalShortcut, session, ipcMain } = electron,
     trayicon = path.join(__dirname, 'assets', 'dist_icon.png');
 process.env.userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36';
+app.commandLine.appendSwitch('disable-features', 'MediaSessionService');
 
 let cfgId, url, win, tray, db = new Datastore({ filename: `${app.getPath('userData')}/deezer.db`, autoload: true });
+
+const player = Player({
+    name: 'Deezer',
+    identity: 'Deezer media player',
+    supportedUriSchemes: [],
+    supportedMimeTypes: [],
+    supportedInterfaces: ['player']
+})
 
 async function createWin() {
     session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
@@ -25,6 +35,7 @@ async function createWin() {
         win = new Window(app, url, electron.screen.getPrimaryDisplay().workAreaSize);
         register_mediaKeys();
         update_tray();
+        init_player_mpris();
     })
 }
 
@@ -103,6 +114,13 @@ function update_tray() {
                 win.restore();
         }
     }, {
+        label: "Hide Window",
+        enabled: true,
+        click: () => {
+            if (win.isVisible())
+                win.hide();
+        }
+    }, {
         label: "Quit",
         enabled: true,
         click: () => {
@@ -114,6 +132,8 @@ function update_tray() {
     tray.on("click", () => {
         if (!win.isVisible())
             win.restore();
+        else
+            win.hide();
     })
     tray.setContextMenu(new Menu.buildFromTemplate(model))
 }
@@ -122,6 +142,145 @@ app.on('ready', createWin)
 app.on('browser-window-created', (e, window) => {
     window.setMenuBarVisibility(false);
 })
+
+function init_player_mpris() {
+    // Start at position 0
+    player.seeked(0);
+    // Bind the deezer events to the mpris datas
+    win.webContents.executeJavaScript(`
+      var electron = require('electron')
+      Events.subscribe(Events.player.playerReady, function(){
+          electron.ipcRenderer.send('readDZCurSong', dzPlayer.getCurrentSong())
+      })
+      Events.subscribe(Events.player.updateCurrentTrack, function(){
+          electron.ipcRenderer.send('readDZCurSong', dzPlayer.getCurrentSong())
+      })
+      Events.subscribe(Events.player.trackChange, function(){
+          electron.ipcRenderer.send('readDZCurSong', dzPlayer.getCurrentSong())
+      })
+      Events.subscribe(Events.player.playing, function(){
+          electron.ipcRenderer.send('readDZPlaying', dzPlayer.isPlaying())
+          electron.ipcRenderer.send('readDZCurSong', dzPlayer.getCurrentSong())
+      })
+      Events.subscribe(Events.player.volume_changed, function(){
+          electron.ipcRenderer.send('readDZVolume', dzPlayer.getVolume())
+      })
+      Events.subscribe(Events.player.shuffle_changed, function(){
+          electron.ipcRenderer.send('readDZShuffle', dzPlayer.shuffle)
+      })
+      Events.subscribe(Events.player.repeat_changed, function(){
+          electron.ipcRenderer.send('readDZRepeat', dzPlayer.getRepeat())
+      })
+      `);
+    // The function used to know when to read the Deezer track position
+    player.getPosition = function() {
+      win.webContents.executeJavaScript(`
+        var electron = require('electron')
+        var value = dzPlayer.getPosition()
+        electron.ipcRenderer.send('readDZCurPosition', value)`);
+    };
+
+    player.on('quit', function () {
+        process.exit();
+    });
+}
+
+// MPRIS side actions
+player.on('pause', function () {
+    win.webContents.executeJavaScript("dzPlayer.control.pause();");
+})
+player.on('play', function () {
+    win.webContents.executeJavaScript("dzPlayer.control.play();");
+})
+player.on('play', function () {
+    win.webContents.executeJavaScript("dzPlayer.control.togglePause();");
+})
+player.on('loopStatus', function () {
+    var repeat_status;
+    switch(player.loopStatus){
+        case "None":
+            player.loopStatus = "Playlist";
+            repeat_status = 1;
+            break;
+        case "Playlist":
+            player.loopStatus = "Track";
+            repeat_status = 2;
+            break;
+        case "Track":
+            player.loopStatus = "None";
+            repeat_status = 0;
+            break;
+    };
+    win.webContents.executeJavaScript(`dzPlayer.control.setRepeat(${repeat_status});`);
+})
+player.on('shuffle', function () {
+    var shuffle_status = arguments['0'];
+    player.shuffle = shuffle_status;
+    win.webContents.executeJavaScript(`dzPlayer.control.setShuffle(${shuffle_status});`);
+})
+player.on('next', function () {
+    win.webContents.executeJavaScript("dzPlayer.control.nextSong();");
+})
+player.on('previous', function () {
+    win.webContents.executeJavaScript("dzPlayer.control.prevSong();");
+})
+player.on('volume', function () {
+    win.webContents.executeJavaScript(`dzPlayer.control.setVolume(${arguments['0']});`);
+})
+player.on('position', function () {
+    var cur_pos = arguments['0']['position'];
+    var length = player.metadata['mpris:length'];
+    win.webContents.executeJavaScript(`dzPlayer.control.seek(${cur_pos/length});`);
+})
+
+// Deezer side actions
+ipcMain.on('readDZCurSong', function(event, data){
+  var song = data;
+  var artists = [];
+  if ('ARTISTS' in song) {
+      song['ARTISTS'].forEach(function(artist){
+          artists.push(artist['ART_NAME']);
+      });
+  }else {
+      artists = [song['ART_NAME']];
+  }
+  player.metadata = {
+      'mpris:trackid': player.objectPath('track/0'),
+      'mpris:length': song['DURATION'] * 1000 * 1000, // In microseconds
+      'mpris:artUrl': 'https://e-cdns-images.dzcdn.net/images/cover/'+song['ALB_PICTURE']+'/380x380-000000-80-0-0.jpg',
+      'xesam:title': song['SNG_TITLE'],
+      'xesam:album': song['ALB_TITLE'],
+      'xesam:artist': artists
+  };
+});
+ipcMain.on('readDZCurPosition', function(event, data){
+  player.seeked(data * 1000 * 1000);
+});
+ipcMain.on('readDZPlaying', function(event, data){
+  if (data)
+    player.playbackStatus = Player.PLAYBACK_STATUS_PLAYING;
+  else
+    player.playbackStatus = Player.PLAYBACK_STATUS_PAUSED;
+});
+ipcMain.on('readDZVolume', function(event, data){
+  player.volume = data;
+});
+ipcMain.on('readDZShuffle', function(event, data){
+  player.shuffle = data;
+});
+ipcMain.on('readDZRepeat', function(event, data){
+  switch(data){
+      case 0:
+          player.loopStatus = "None";
+          break;
+      case 1:
+          player.loopStatus = "Playlist";
+          break;
+      case 2:
+          player.loopStatus = "Track";
+          break;
+  };
+});
 
 async function saveData() {
     if (cfgId) {

--- a/src/app.js
+++ b/src/app.js
@@ -192,7 +192,7 @@ player.on('pause', function () {
 player.on('play', function () {
     win.webContents.executeJavaScript("dzPlayer.control.play();");
 })
-player.on('play', function () {
+player.on('playpause', function () {
     win.webContents.executeJavaScript("dzPlayer.control.togglePause();");
 })
 player.on('loopStatus', function () {

--- a/src/app.js
+++ b/src/app.js
@@ -109,20 +109,6 @@ function update_tray() {
         label: "APP",
         enabled: false
     }, {
-        label: "Show Window",
-        enabled: true,
-        click: () => {
-            if (!win.isVisible())
-                win.restore();
-        }
-    }, {
-        label: "Hide Window",
-        enabled: true,
-        click: () => {
-            if (win.isVisible())
-                win.hide();
-        }
-    }, {
         label: "Quit",
         enabled: true,
         click: () => {

--- a/src/package.json
+++ b/src/package.json
@@ -30,6 +30,7 @@
     },
     "dependencies": {
         "nedb": "^1.8.0",
+        "mpris-service": "^1.1.4",
         "path": "^0.12.7"
     }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "nedb": "^1.8.0",
-        "mpris-service": "^1.1.4",
+        "mpris-service": "^2.1.2",
         "path": "^0.12.7"
     }
 }

--- a/src/utils/window.js
+++ b/src/utils/window.js
@@ -8,6 +8,7 @@ class Window extends BrowserWindow {
             title: "Deezer Player",
             icon: path.join(__dirname, '..', 'assets', 'dist_icon.png'),
             webPreferences: {
+                nodeIntegration: true,
                 nativeWindowOpen: true,
                 devTools: false,
                 contextIsolation: false


### PR DESCRIPTION
Previously, only chromium was communicating the track infos to the system.
This patch allows the electron app to give to the system more informations and control about the music played.

I also added the ability to click on the tray icon to hide/show the window (I just added the hide).